### PR TITLE
Tighten resilient apps intro

### DIFF
--- a/_posts/2026-08-08-building-resilient-personal-apps.md
+++ b/_posts/2026-08-08-building-resilient-personal-apps.md
@@ -7,13 +7,11 @@ and how taking care of them feels more like tending a garden than running a
 product. Mowing the lawn and weeding, with the occasional prune. That metaphor
 still feels right to me, but I've started thinking more concretely about what
 happens when a project reaches the point where I actually use it most days, and
-what "resilient" means in that situation.
-
-For me, it's not about uptime SLAs or on-call rotations. It's more about being
-able to trust that I can leave a project alone for a few weeks, come back to it,
-and find it in roughly the same shape I left it. The patches have been applied.
-The tests are still green. I know which version is running on the box under my
-desk. [Aotearoa, Again](https://github.com/joshmcarthur/aotearoa-again) is the
+what "resilient" means in that situation. Mostly, it means the codebase stays
+current without me having to think about it every week. I want to be able to
+leave a project alone for a few weeks, come back to it, and find it in roughly
+the same shape I left it. The patches have been applied. The tests are still
+green. I know which version is running on the box under my desk. [Aotearoa, Again](https://github.com/joshmcarthur/aotearoa-again) is the
 project where I've been experimenting with this lately: a daily publishing app I
 want to still be happy running in a year, without maintenance becoming a project
 in its own right. There's a [case study](/case-studies/aotearoa-again/) on the


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove the uptime SLAs / on-call tangent from the intro and connect resilience directly to keeping the codebase current.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdff5-9dfa-7b7f-a496-69a6b906f8a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdff5-9dfa-7b7f-a496-69a6b906f8a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

