### PR TITLE
Generalise Aotearoa-specific references in resilient apps post

### DIFF
--- a/_posts/2026-08-08-building-resilient-personal-apps.md
+++ b/_posts/2026-08-08-building-resilient-personal-apps.md
@@ -21,9 +21,8 @@ side if you're curious. This post is mostly about the maintenance side of that.
 I've found that certain kinds of work on a personal app are really easy to put
 off. They're low-risk when done carefully, but important enough that
 procrastinating on them eventually bites you. Those are the things I try to
-automate. What I keep manual is the part I actually enjoy: building features,
-reviewing major upgrades, and signing off on each day's photo before it goes
-live.
+automate. What I keep manual is the part I actually enjoy: building features
+and reviewing major upgrades.
 
 I don't want to remember to check for gem or GitHub Actions updates, so
 Dependabot opens PRs on a weekly schedule for both, with a cap on how many can
@@ -52,7 +51,7 @@ enough that I trust it.
 That said, automation has limits, and I'm fine with that. Major dependency
 upgrades I still do myself. Same for new features and production credentials.
 I'd rather review a Rails minor bump myself than discover a subtle breaking
-change on a Tuesday morning when the daily edition is due to publish. The goal
+change at an awkward moment. The goal
 isn't a hands-off app. It's an app that handles the boring continuity work so
 that when I do sit down to work on it, I'm doing something interesting rather
 than catching up on housekeeping.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Generalise two Aotearoa-specific references (photo sign-off and daily edition deadline) so the post reads as about personal app maintenance in general.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdff5-9dfa-7b7f-a496-69a6b906f8a2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdff5-9dfa-7b7f-a496-69a6b906f8a2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

